### PR TITLE
Manage boolean fields and add not nullable fiels on required

### DIFF
--- a/src/Strategy/DoctrineMetadataStrategy.php
+++ b/src/Strategy/DoctrineMetadataStrategy.php
@@ -64,6 +64,10 @@ class DoctrineMetadataStrategy implements StrategyInterface
                 $format = 'time';
             }
 
+            if (in_array($property['type'], ['boolean'])) {
+                $type = 'boolean';
+            }
+
             //Warn
             if ($type === null) {
                 $type = 'string';
@@ -86,7 +90,7 @@ class DoctrineMetadataStrategy implements StrategyInterface
             /*
              * Validating input data, the id might not be present if a resource doesn't exist yet
              */
-            if (isset($property['id'])) {
+            if (isset($property['id']) || ((isset($property['nullable']) && $property['nullable'] === true))) {
                 $prop['type'] = [$prop['type'], 'null'];
             }
 

--- a/tests/DependencyInjection/JsonSchemaExtensionTest.php
+++ b/tests/DependencyInjection/JsonSchemaExtensionTest.php
@@ -60,7 +60,7 @@ class JsonSchemaExtensionTest extends \PHPUnit_Framework_TestCase
 
         $containerBuilderProphecy->setParameter('json_schema.path', 'test')->shouldBeCalled();
 
-        $containerBuilderProphecy->addResource(Argument::type(ResourceInterface::class))->shouldBeCalled();
+        $containerBuilderProphecy->fileExists(Argument::any())->shouldBeCalled();
 
         $definitions = [
             'json_schema.validator',

--- a/tests/Strategy/DoctrineMetadataStrategyTest.php
+++ b/tests/Strategy/DoctrineMetadataStrategyTest.php
@@ -26,11 +26,17 @@ class DoctrineMetadataStrategyTest extends \PHPUnit_Framework_TestCase
         'type' => 'object',
         'properties' => [
             'id' => [
-            'type' => ['integer', 'null'],
+                'type' => ['integer', 'null'],
             ],
-            'name' => ['type' => 'string'],
-            'description' => ['type' => 'string'],
-            'price' => ['type' => 'number'],
+            'name' => [
+                'type' => 'string'
+            ],
+            'description' => [
+                'type' => ['string', 'null'],
+            ],
+            'price' => [
+                'type' => ['number', 'null'],
+            ],
         ],
         'required' => ['id', 'name'],
         ]);


### PR DESCRIPTION
I changed a little the Doctrine strategy to:
- support bollean values as "boolean" instead of "string" (see https://spacetelescope.github.io/understanding-json-schema/reference/boolean.html)
- add any nullable=false files on the required array